### PR TITLE
Removes implicit capture of 'this'

### DIFF
--- a/include/bvh/vector.hpp
+++ b/include/bvh/vector.hpp
@@ -52,11 +52,11 @@ struct Vector {
     }
 
     bvh__always_inline__ Vector operator - () const {
-        return Vector([=] (size_t i) { return -values[i]; });
+        return Vector([this] (size_t i) { return -values[i]; });
     }
 
     bvh__always_inline__ Vector inverse() const {
-        return Vector([=] (size_t i) { return Scalar(1) / values[i]; });
+        return Vector([this] (size_t i) { return Scalar(1) / values[i]; });
     }
 
     bvh__always_inline__ Scalar& operator [] (size_t i) { return values[i]; }


### PR DESCRIPTION
Implicit capture of 'this' via '[=]' has been deprecated in C++20; P0806R2 ; http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p0806r2.html