### PR TITLE
fix inconsistent naming between triangle/sphere primitives

### DIFF
--- a/include/bvh/sphere.hpp
+++ b/include/bvh/sphere.hpp
@@ -33,7 +33,7 @@ struct Sphere  {
         return origin;
     }
 
-    BoundingBox<Scalar> bbox() const {
+    BoundingBox<Scalar> bounding_box() const {
         return BoundingBox<Scalar>(origin - Vector3<Scalar>(radius), origin + Vector3<Scalar>(radius));
     }
 


### PR DESCRIPTION
A typo in the `Sphere` geometry makes it unable to compile when using both `Sphere` and `Triangle` primitives in a generic template over primitive type...this addresses the problem.