### PR TITLE
Prevent floating point conversion if ScalarType isn't single precision.

### DIFF
--- a/include/bvh/primitive_intersectors.hpp
+++ b/include/bvh/primitive_intersectors.hpp
@@ -59,7 +59,7 @@ struct AnyPrimitiveIntersector : public PrimitiveIntersector<Bvh, Primitive, Pre
     using Scalar = typename Primitive::ScalarType;
 
     struct Result {
-        float t;
+        Scalar t;
         Scalar distance() const { return t; }
     };
 


### PR DESCRIPTION
I had a compiler warning that was triggered by this problem...