### PR TITLE
fix 'unknown pragma' warning in clang-cl

### DIFF
--- a/include/bvh/utilities.hpp
+++ b/include/bvh/utilities.hpp
@@ -36,7 +36,7 @@ inline double product_sign(double x, double y) {
 
 /// Performs a multiplication followed by an addition, using a fused multiply-add
 /// instruction if available, or a regular multiplication followed by an addition, if not.
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && not defined(__clang__)
 #pragma float_control(push)
 #pragma float_control(precise, off)
 #pragma fp_contract(on)
@@ -52,7 +52,7 @@ bvh_always_inline T fast_multiply_add(T x, T y, T z) {
     return x * y + z;
 #endif
 }
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && not defined(__clang__)
 #pragma float_control(pop)
 #endif
 


### PR DESCRIPTION
When using clang-cl (LLVM toolset in Visual Studio), both `_MSC_VER` and `__clang__` are defined. And clang-cl complains `warning : unknown pragma` for `#pragma fp_contract(on)`. This pr adds an additional condition to detect that.