### PR TITLE
fix osx compilation with clang version 12.0.0

### DIFF
--- a/src/bvh/v2/tri.h
+++ b/src/bvh/v2/tri.h
@@ -21,7 +21,7 @@ struct Tri {
         : p0(p0), p1(p1), p2(p2)
     {}
 
-    BVH_ALWAYS_INLINE BBox<T, 3> get_bbox() const { return BBox(p0).extend(p1).extend(p2); }
+    BVH_ALWAYS_INLINE BBox<T, 3> get_bbox() const { return BBox<T, N>(p0).extend(p1).extend(p2); }
     BVH_ALWAYS_INLINE Vec<T, 3> get_center() const { return (p0 + p1 + p2) * static_cast<T>(1. / 3.); }
 };
 


### PR DESCRIPTION
Fix OSX compilation

```
Apple clang version 12.0.0 (clang-1200.0.32.27)
```

```
In file included from bvh/test/simple_example.cpp:9:
bvh/v2/../../bvh/v2/tri.h:24:68: error: member reference base type 'BBox' is not a structure or union
    BVH_ALWAYS_INLINE BBox<T, 3> get_bbox() const { return BBox(p0).extend(p1).extend(p2); }
                                                           ~~~~~~~~^~~~~~~
```