### PR TITLE
Add bvh traversal function

### DIFF
--- a/src/bvh/v2/bvh.h
+++ b/src/bvh/v2/bvh.h
@@ -125,8 +125,7 @@ restart:
                     stack.push(far_index);
                 }
                 top = near_index;
-			}
-			else if (hit_right)
+			} else if (hit_right)
 				top = right.index;
             else [[unlikely]]
                 goto restart;
@@ -156,8 +155,7 @@ restart:
 				if (hit_right)
 					stack.push(right.index);
 				top = near_index;
-			}
-			else if (hit_right)
+			} else if (hit_right)
 				top = right.index;
 			else [[unlikely]]
 				goto restart;

--- a/src/bvh/v2/bvh.h
+++ b/src/bvh/v2/bvh.h
@@ -41,8 +41,8 @@ struct Bvh {
     template <bool IsAnyHit, bool IsRobust, typename Stack, typename LeafFn, typename InnerFn = IgnoreArgs>
     inline void intersect(Ray<Scalar, Node::dimension>& ray, Index top, Stack&, LeafFn&&, InnerFn&& = {}) const;
 
-    template <bool IsAnyHit, typename Stack, typename LeafFn, typename InnerFn = IgnoreArgs>
-    inline void traverse(Index top, Stack&, LeafFn&&, InnerFn && = {}) const;
+	template <bool IsAnyHit, typename Stack, typename LeafFn, typename InnerFn = std::tuple<bool,bool>(*)(const Node&, const Node&)>
+    inline void traverse(Index top, Stack&, LeafFn&&, InnerFn&& = [](const Node&, const Node&) { return std::make_tuple(true, true); }) const;
 
     inline void serialize(OutputStream&) const;
     static inline Bvh deserialize(InputStream&);

--- a/src/bvh/v2/bvh.h
+++ b/src/bvh/v2/bvh.h
@@ -120,8 +120,9 @@ restart:
                     stack.push(far_index);
                 }
                 top = near_index;
-            } else if (hit_right)
-                top = right.index;
+			}
+			else if (hit_right)
+				top = right.index;
             else [[unlikely]]
                 goto restart;
         }
@@ -144,10 +145,7 @@ restart:
 			auto& left = nodes[top.first_id];
 			auto& right = nodes[top.first_id + 1];
 
-			bool hit_left = false;
-			bool hit_right = false;
-			inner_fn(left, right, hit_left, hit_right);
-
+			auto [hit_left, hit_right] = inner_fn(left, right);
 			if (hit_left) {
 				auto near_index = left.index;
 				if (hit_right)

--- a/src/bvh/v2/bvh.h
+++ b/src/bvh/v2/bvh.h
@@ -41,8 +41,13 @@ struct Bvh {
     template <bool IsAnyHit, bool IsRobust, typename Stack, typename LeafFn, typename InnerFn = IgnoreArgs>
     inline void intersect(Ray<Scalar, Node::dimension>& ray, Index top, Stack&, LeafFn&&, InnerFn&& = {}) const;
 
-	template <bool IsAnyHit, typename Stack, typename LeafFn, typename InnerFn = std::tuple<bool,bool>(*)(const Node&, const Node&)>
-    inline void traverse(Index top, Stack&, LeafFn&&, InnerFn&& = [](const Node&, const Node&) { return std::make_tuple(true, true); }) const;
+    /// Traverses the BVH tree, starting at the node index `top` and using the given stack object.
+    /// `inner_fn` is called for every non-leaf node and returns two boolean values which indicate
+    /// whether traversal should continue for the left/right child branches. Returning false for
+    /// either will end traversal for that branch. Likewise `leaf_fn` is called for every leaf node.
+    /// When `IsAnyHit` is true, the function stops the first time `leaf_fn` returns true.
+    template <bool IsAnyHit, typename Stack, typename LeafFn, typename InnerFn = std::tuple<bool,bool>(*)(const Node&, const Node&)>
+    inline void traverse(Index top, Stack&, LeafFn&& leaf_fn, InnerFn&& inner_fn = [](const Node&, const Node&) { return std::make_tuple(true, true); }) const;
 
     inline void serialize(OutputStream&) const;
     static inline Bvh deserialize(InputStream&);

--- a/src/bvh/v2/bvh.h
+++ b/src/bvh/v2/bvh.h
@@ -41,8 +41,8 @@ struct Bvh {
     template <bool IsAnyHit, bool IsRobust, typename Stack, typename LeafFn, typename InnerFn = IgnoreArgs>
     inline void intersect(Ray<Scalar, Node::dimension>& ray, Index top, Stack&, LeafFn&&, InnerFn&& = {}) const;
 
-	template <bool IsAnyHit, typename Stack, typename LeafFn, typename InnerFn = IgnoreArgs>
-	inline void traverse(Index top, Stack&, LeafFn&&, InnerFn && = {}) const;
+    template <bool IsAnyHit, typename Stack, typename LeafFn, typename InnerFn = IgnoreArgs>
+    inline void traverse(Index top, Stack&, LeafFn&&, InnerFn && = {}) const;
 
     inline void serialize(OutputStream&) const;
     static inline Bvh deserialize(InputStream&);

--- a/src/bvh/v2/bvh.h
+++ b/src/bvh/v2/bvh.h
@@ -125,8 +125,8 @@ restart:
                     stack.push(far_index);
                 }
                 top = near_index;
-			} else if (hit_right)
-				top = right.index;
+            } else if (hit_right)
+                top = right.index;
             else [[unlikely]]
                 goto restart;
         }
@@ -141,31 +141,31 @@ restart:
 template <typename Node>
 template <bool IsAnyHit, typename Stack, typename LeafFn, typename InnerFn>
 void Bvh<Node>::traverse(Index start, Stack& stack, LeafFn&& leaf_fn, InnerFn&& inner_fn) const {
-	stack.push(start);
+    stack.push(start);
 restart:
-	while (!stack.is_empty()) {
-		auto top = stack.pop();
-		while (top.prim_count == 0) {
-			auto& left = nodes[top.first_id];
-			auto& right = nodes[top.first_id + 1];
+    while (!stack.is_empty()) {
+        auto top = stack.pop();
+        while (top.prim_count == 0) {
+            auto& left = nodes[top.first_id];
+            auto& right = nodes[top.first_id + 1];
 
-			auto [hit_left, hit_right] = inner_fn(left, right);
-			if (hit_left) {
-				auto near_index = left.index;
-				if (hit_right)
-					stack.push(right.index);
-				top = near_index;
-			} else if (hit_right)
-				top = right.index;
-			else [[unlikely]]
-				goto restart;
-		}
+            auto [hit_left, hit_right] = inner_fn(left, right);
+            if (hit_left) {
+                auto near_index = left.index;
+                if (hit_right)
+                    stack.push(right.index);
+                top = near_index;
+            } else if (hit_right)
+                top = right.index;
+            else [[unlikely]]
+                goto restart;
+        }
 
-		[[maybe_unused]] auto was_hit = leaf_fn(top.first_id, top.first_id + top.prim_count);
-		if constexpr (IsAnyHit) {
-			if (was_hit) return;
-		}
-	}
+        [[maybe_unused]] auto was_hit = leaf_fn(top.first_id, top.first_id + top.prim_count);
+        if constexpr (IsAnyHit) {
+            if (was_hit) return;
+        }
+    }
 }
 
 template <typename Node>


### PR DESCRIPTION
Added `Bvh<>::traverse`, a simplified version of `intersect` without the default intersection checks. 
This can be used, for example, if you want to traverse the tree to find all primitives within an AABB.

The user can skip left/right branches early using the return values of `inner_fn`.