### PR TITLE
Rework node index data type

### DIFF
--- a/src/bvh/v2/index.h
+++ b/src/bvh/v2/index.h
@@ -1,0 +1,83 @@
+#ifndef BVH_V2_INDEX_H
+#define BVH_V2_INDEX_H
+
+#include "bvh/v2/utils.h"
+
+#include <cassert>
+#include <cstddef>
+
+namespace bvh::v2 {
+
+/// Packed index data structure. This index can either refer to a range of primitives for a BVH
+/// leaf, or to the children of a BVH node. In either case, the index corresponds to a contiguous
+/// range, which means that:
+///
+/// - For leaves, primitives in a BVH node should be accessed via:
+///
+///     size_t begin = index.first_id();
+///     size_t end   = begin + index.prim_count();
+///     for (size_t i = begin; i < end; ++i) {
+///         size_t prim_id = bvh.prim_ids[i];
+///         // ...
+///     }
+///
+///   Note that for efficiency, reordering the original data to avoid the indirection via
+///   `bvh.prim_ids` is preferable.
+///
+/// - For inner nodes, children should be accessed via:
+///
+///   auto& left_child = bvh.nodes[index.first_id()];
+///   auto& right_child = bvh.nodes[index.first_id() + 1];
+///
+template <size_t Bits, size_t PrimCountBits>
+struct Index {
+    using Type = UnsignedIntType<Bits>;
+
+    static constexpr size_t bits = Bits;
+    static constexpr size_t prim_count_bits = PrimCountBits;
+    static constexpr Type max_prim_count = make_bitmask<Type>(prim_count_bits);
+
+    static_assert(PrimCountBits < Bits);
+
+    Type value;
+
+    Index() = default;
+    explicit Index(Type value) : value(value) {}
+
+    bool operator == (const Index&) const = default;
+    bool operator != (const Index&) const = default;
+
+    BVH_ALWAYS_INLINE Type first_id() const { return value >> prim_count_bits; }
+    BVH_ALWAYS_INLINE Type prim_count() const { return value & max_prim_count; }
+    BVH_ALWAYS_INLINE bool is_leaf() const { return prim_count() != 0; }
+    BVH_ALWAYS_INLINE bool is_inner() const { return !is_leaf(); }
+
+    BVH_ALWAYS_INLINE void set_first_id(Type first_id) {
+        *this = Index { first_id, prim_count() };
+    }
+
+    BVH_ALWAYS_INLINE void set_prim_count(Type prim_count) {
+        *this = Index { first_id(), prim_count };
+    }
+
+    static BVH_ALWAYS_INLINE Index make_leaf(Type first_prim, Type prim_count) {
+        assert(prim_count != 0);
+        return Index { first_prim, prim_count };
+    }
+
+    static BVH_ALWAYS_INLINE Index make_inner(Type first_child) {
+        return Index { first_child, 0 };
+    }
+
+private:
+    explicit Index(Type first_id, Type prim_count)
+        : value((first_id << prim_count_bits) | (prim_count & max_prim_count))
+    {
+        assert(first_id <= make_bitmask<Type>(Bits - PrimCountBits));
+        assert(prim_count <= max_prim_count);
+    }
+};
+
+} // namespace bvh::v2
+
+#endif

--- a/src/bvh/v2/mini_tree_builder.h
+++ b/src/bvh/v2/mini_tree_builder.h
@@ -225,8 +225,8 @@ private:
                 if (node.get_bbox().get_half_area() < threshold || node.is_leaf()) {
                     pruned_roots.emplace_back(i, node_id);
                 } else {
-                    stack.push(node.index.first_id);
-                    stack.push(node.index.first_id + 1);
+                    stack.push(node.index.first_id());
+                    stack.push(node.index.first_id() + 1);
                 }
             }
         }
@@ -274,16 +274,16 @@ private:
         // Helper function to copy and fix the child/primitive index of a node
         auto copy_node = [&] (size_t i, Node& dst_node, const Node& src_node) {
             dst_node = src_node;
-            dst_node.index.first_id += static_cast<typename Node::Index::Type>(
-                src_node.is_leaf() ? prim_offsets[i] : node_offsets[i]);
+            dst_node.index.set_first_id(dst_node.index.first_id() +
+                (src_node.is_leaf() ? prim_offsets[i] : node_offsets[i]));
         };
 
         // Make the leaves of the top BVH point to the right internal nodes
         for (auto& node : bvh.nodes) {
             if (!node.is_leaf())
                 continue;
-            assert(node.index.prim_count == 1);
-            size_t tree_id = bvh.prim_ids[node.index.first_id];
+            assert(node.index.prim_count() == 1);
+            size_t tree_id = bvh.prim_ids[node.index.first_id()];
             copy_node(tree_id, node, mini_trees[tree_id].get_root());
         }
 

--- a/src/bvh/v2/top_down_sah_builder.h
+++ b/src/bvh/v2/top_down_sah_builder.h
@@ -89,7 +89,7 @@ protected:
             if (item.size() > config_.min_leaf_size) {
                 if (auto split_pos = try_split(node.get_bbox(), item.begin, item.end)) {
                     auto first_child = bvh.nodes.size();
-                    node.make_inner(first_child);
+                    node.index = Node::Index::make_inner(first_child);
 
                     bvh.nodes.resize(first_child + 2);
 
@@ -122,7 +122,7 @@ protected:
                 }
             }
 
-            node.make_leaf(item.begin, item.size());
+            node.index = Node::Index::make_leaf(item.begin, item.size());
         }
 
         bvh.prim_ids = std::move(get_prim_ids());


### PR DESCRIPTION
- Add separate header `index.h` to simplify code structure
- Fix serialization of indices (issue #77)
- Add comments to describe the meaning of BVH indices (issue #78)