### PR TITLE
Fix for issue #97

### DIFF
--- a/src/bvh/v2/bvh.h
+++ b/src/bvh/v2/bvh.h
@@ -81,7 +81,10 @@ struct Bvh {
     template <typename LeafFn = IgnoreArgs>
     inline void refit(LeafFn&& = {});
 
+    template <typename IndexType = typename Index::Type>
     inline void serialize(OutputStream&) const;
+
+    template <typename IndexType = typename Index::Type>
     static inline Bvh deserialize(InputStream&);
 };
 
@@ -215,24 +218,26 @@ void Bvh<Node>::refit(LeafFn&& leaf_fn) {
 }
 
 template <typename Node>
+template <typename IndexType>
 void Bvh<Node>::serialize(OutputStream& stream) const {
-    stream.write(nodes.size());
-    stream.write(prim_ids.size());
+    stream.write(static_cast<IndexType>(nodes.size()));
+    stream.write(static_cast<IndexType>(prim_ids.size()));
     for (auto&& node : nodes)
         node.serialize(stream);
     for (auto&& prim_id : prim_ids)
-        stream.write(prim_id);
+        stream.write(static_cast<IndexType>(prim_id));
 }
 
 template <typename Node>
+template <typename IndexType>
 Bvh<Node> Bvh<Node>::deserialize(InputStream& stream) {
     Bvh bvh;
-    bvh.nodes.resize(stream.read<size_t>());
-    bvh.prim_ids.resize(stream.read<size_t>());
+    bvh.nodes.resize(stream.read<IndexType>());
+    bvh.prim_ids.resize(stream.read<IndexType>());
     for (auto& node : bvh.nodes)
         node = Node::deserialize(stream);
     for (auto& prim_id : bvh.prim_ids)
-        prim_id = stream.read<size_t>();
+        prim_id = stream.read<IndexType>();
     return bvh;
 }
 


### PR DESCRIPTION
This makes sure primitive indices and other integer values use an architecture/system-independent type.