### PR TITLE
Add `nodiscard` attributes in various key places (issue #99)

### DIFF
--- a/src/bvh/v2/binned_sah_builder.h
+++ b/src/bvh/v2/binned_sah_builder.h
@@ -29,7 +29,7 @@ class BinnedSahBuilder : public TopDownSahBuilder<Node> {
 public:
     using typename TopDownSahBuilder<Node>::Config;
 
-    BVH_ALWAYS_INLINE static Bvh<Node> build(
+    [[nodiscard]] BVH_ALWAYS_INLINE static Bvh<Node> build(
         std::span<const BBox> bboxes,
         std::span<const Vec> centers,
         const Config& config = {})

--- a/src/bvh/v2/bvh.h
+++ b/src/bvh/v2/bvh.h
@@ -54,7 +54,7 @@ struct Bvh {
     BVH_ALWAYS_INLINE const Node& get_root() const { return nodes[0]; }
 
     /// Extracts the BVH rooted at the given node index.
-    inline Bvh extract_bvh(size_t root_id) const;
+    [[nodiscard]] inline Bvh extract_bvh(size_t root_id) const;
 
     /// Traverses the BVH from the given index in `start` using the provided stack. Every leaf
     /// encountered on the way is processed using the given `LeafFn` function, and every pair of
@@ -85,7 +85,7 @@ struct Bvh {
     inline void serialize(OutputStream&) const;
 
     template <typename IndexType = typename Index::Type>
-    static inline Bvh deserialize(InputStream&);
+    [[nodiscard]] static inline Bvh deserialize(InputStream&);
 };
 
 template <typename Node>

--- a/src/bvh/v2/default_builder.h
+++ b/src/bvh/v2/default_builder.h
@@ -30,7 +30,7 @@ public:
     };
 
     /// Build a BVH in parallel using the given thread pool.
-    BVH_ALWAYS_INLINE static Bvh<Node> build(
+    [[nodiscard]] BVH_ALWAYS_INLINE static Bvh<Node> build(
         ThreadPool& thread_pool,
         std::span<const BBox> bboxes,
         std::span<const Vec> centers,
@@ -46,7 +46,7 @@ public:
     }
 
     /// Build a BVH in a single-thread.
-    BVH_ALWAYS_INLINE static Bvh<Node> build(
+    [[nodiscard]] BVH_ALWAYS_INLINE static Bvh<Node> build(
         std::span<const BBox>  bboxes,
         std::span<const Vec> centers,
         const Config& config = {})

--- a/src/bvh/v2/executor.h
+++ b/src/bvh/v2/executor.h
@@ -13,12 +13,12 @@ namespace bvh::v2 {
 template <typename Derived>
 struct Executor {
     template <typename Loop>
-    inline void for_each(size_t begin, size_t end, const Loop& loop) {
+    BVH_ALWAYS_INLINE void for_each(size_t begin, size_t end, const Loop& loop) {
         return static_cast<Derived*>(this)->for_each(begin, end, loop);
     }
 
     template <typename T, typename Reduce, typename Join>
-    inline T reduce(size_t begin, size_t end, const T& init, const Reduce& reduce, const Join& join) {
+    BVH_ALWAYS_INLINE T reduce(size_t begin, size_t end, const T& init, const Reduce& reduce, const Join& join) {
         return static_cast<Derived*>(this)->reduce(begin, end, init, reduce, join);
     }
 };
@@ -26,12 +26,12 @@ struct Executor {
 /// Executor that executes serially.
 struct SequentialExecutor : Executor<SequentialExecutor> {
     template <typename Loop>
-    void for_each(size_t begin, size_t end, const Loop& loop) {
+    BVH_ALWAYS_INLINE void for_each(size_t begin, size_t end, const Loop& loop) {
         loop(begin, end);
     }
 
     template <typename T, typename Reduce, typename Join>
-    T reduce(size_t begin, size_t end, const T& init, const Reduce& reduce, const Join&) {
+    BVH_ALWAYS_INLINE T reduce(size_t begin, size_t end, const T& init, const Reduce& reduce, const Join&) {
         T result(init);
         reduce(result, begin, end);
         return result;
@@ -48,7 +48,7 @@ struct ParallelExecutor : Executor<ParallelExecutor> {
     {}
 
     template <typename Loop>
-    void for_each(size_t begin, size_t end, const Loop& loop) {
+    BVH_ALWAYS_INLINE void for_each(size_t begin, size_t end, const Loop& loop) {
         if (end - begin < parallel_threshold)
             return loop(begin, end);
 
@@ -61,7 +61,7 @@ struct ParallelExecutor : Executor<ParallelExecutor> {
     }
 
     template <typename T, typename Reduce, typename Join>
-    T reduce(size_t begin, size_t end, const T& init, const Reduce& reduce, const Join& join) {
+    BVH_ALWAYS_INLINE T reduce(size_t begin, size_t end, const T& init, const Reduce& reduce, const Join& join) {
         if (end - begin < parallel_threshold) {
             T result(init);
             reduce(result, begin, end);

--- a/src/bvh/v2/mini_tree_builder.h
+++ b/src/bvh/v2/mini_tree_builder.h
@@ -44,7 +44,7 @@ public:
 
     /// Starts building a BVH with the given primitive data. The build algorithm is multi-threaded,
     /// and runs on the given thread pool.
-    BVH_ALWAYS_INLINE static Bvh<Node> build(
+    [[nodiscard]] BVH_ALWAYS_INLINE static Bvh<Node> build(
         ThreadPool& thread_pool,
         std::span<const BBox> bboxes,
         std::span<const Vec> centers,

--- a/src/bvh/v2/node.h
+++ b/src/bvh/v2/node.h
@@ -65,7 +65,7 @@ struct Node {
     }
 
     /// Robust ray-node intersection routine. See "Robust BVH Ray Traversal", by T. Ize.
-    BVH_ALWAYS_INLINE std::pair<T, T> intersect_robust(
+    [[nodiscard]] BVH_ALWAYS_INLINE std::pair<T, T> intersect_robust(
         const Ray<T, Dim>& ray,
         const Vec<T, Dim>& inv_dir,
         const Vec<T, Dim>& inv_dir_pad,
@@ -76,7 +76,7 @@ struct Node {
         return make_intersection_result(ray, tmin, tmax);
     }
 
-    BVH_ALWAYS_INLINE std::pair<T, T> intersect_fast(
+    [[nodiscard]] BVH_ALWAYS_INLINE std::pair<T, T> intersect_fast(
         const Ray<T, Dim>& ray,
         const Vec<T, Dim>& inv_dir,
         const Vec<T, Dim>& inv_org,
@@ -93,7 +93,7 @@ struct Node {
         stream.write(index.value);
     }
 
-    static BVH_ALWAYS_INLINE Node deserialize(InputStream& stream) {
+    [[nodiscard]] static BVH_ALWAYS_INLINE Node deserialize(InputStream& stream) {
         Node node;
         for (auto& bound : node.bounds)
             bound = stream.read<T>();

--- a/src/bvh/v2/sphere.h
+++ b/src/bvh/v2/sphere.h
@@ -29,7 +29,7 @@ struct Sphere  {
     /// Intersects a ray with the sphere. If the ray is normalized, a dot product can be saved by
     /// setting `AssumeNormalized` to true.
     template <bool AssumeNormalized = false>
-    BVH_ALWAYS_INLINE std::optional<std::pair<T, T>> intersect(const Ray<T, N>& ray) const {
+    [[nodiscard]] BVH_ALWAYS_INLINE std::optional<std::pair<T, T>> intersect(const Ray<T, N>& ray) const {
         auto oc = ray.org - center;
         auto a = AssumeNormalized ? static_cast<T>(1.) : dot(ray.dir, ray.dir);
         auto b = static_cast<T>(2.) * dot(ray.dir, oc);

--- a/src/bvh/v2/sweep_sah_builder.h
+++ b/src/bvh/v2/sweep_sah_builder.h
@@ -27,7 +27,7 @@ class SweepSahBuilder : public TopDownSahBuilder<Node> {
 public:
     using typename TopDownSahBuilder<Node>::Config;
 
-    BVH_ALWAYS_INLINE static Bvh<Node> build(
+    [[nodiscard]] BVH_ALWAYS_INLINE static Bvh<Node> build(
         std::span<const BBox> bboxes,
         std::span<const Vec> centers,
         const Config& config = {})

--- a/src/bvh/v2/vec.h
+++ b/src/bvh/v2/vec.h
@@ -123,7 +123,7 @@ BVH_ALWAYS_INLINE T length(const Vec<T, N>& v) {
 }
 
 template <typename T, size_t N>
-BVH_ALWAYS_INLINE Vec<T, N> normalize(const Vec<T, N>& v) {
+[[nodiscard]] BVH_ALWAYS_INLINE Vec<T, N> normalize(const Vec<T, N>& v) {
     return v * (static_cast<T>(1.) / length(v));
 }
 

--- a/test/benchmark.cpp
+++ b/test/benchmark.cpp
@@ -283,8 +283,10 @@ static size_t intersect_accel(Ray& ray, const Accel& accel, TraversalStats& stat
                 stats.visited_leaves++;
             for (size_t i = begin; i < end; ++i) {
                 size_t j = PermutePrims ? i : accel.bvh.prim_ids[i];
-                if (accel.tris[j].intersect(ray))
+                if (auto hit = accel.tris[j].intersect(ray)) {
+                    ray.tmax = std::get<0>(*hit);
                     prim_id = j;
+                }
             }
             return prim_id != invalid_id;
         },

--- a/test/simple_example.cpp
+++ b/test/simple_example.cpp
@@ -85,7 +85,7 @@ int main() {
                 size_t j = should_permute ? i : bvh.prim_ids[i];
                 if (auto hit = precomputed_tris[j].intersect(ray)) {
                     prim_id = i;
-                    std::tie(u, v) = *hit;
+                    std::tie(ray.tmax, u, v) = *hit;
                 }
             }
             return prim_id != invalid_id;


### PR DESCRIPTION
Warning: This change is breaking the API, since the precomputed triangle intersection function now no longer modifies the ray in place. The traversal routine is expected to update the ray `tmax` value in order to achieve good performance.