### PR TITLE
Threadpool race condition

### DIFF
--- a/src/bvh/v2/executor.h
+++ b/src/bvh/v2/executor.h
@@ -53,11 +53,12 @@ struct ParallelExecutor : Executor<ParallelExecutor> {
             return loop(begin, end);
 
         auto chunk_size = std::max(size_t{1}, (end - begin) / thread_pool.get_thread_count());
+        ThreadPool::TaskGroup group;
         for (size_t i = begin; i < end; i += chunk_size) {
             size_t next = std::min(end, i + chunk_size);
-            thread_pool.push([=] (size_t) { loop(i, next); });
+            thread_pool.push(group, [=] (size_t) { loop(i, next); });
         }
-        thread_pool.wait();
+        thread_pool.wait(group);
     }
 
     template <typename T, typename Reduce, typename Join>
@@ -70,14 +71,15 @@ struct ParallelExecutor : Executor<ParallelExecutor> {
 
         auto chunk_size = std::max(size_t{1}, (end - begin) / thread_pool.get_thread_count());
         std::vector<T> per_thread_result(thread_pool.get_thread_count(), init);
+        ThreadPool::TaskGroup group;
         for (size_t i = begin; i < end; i += chunk_size) {
             size_t next = std::min(end, i + chunk_size);
-            thread_pool.push([&, i, next] (size_t thread_id) {
+            thread_pool.push(group, [&, i, next] (size_t thread_id) {
                 auto& result = per_thread_result[thread_id];
                 reduce(result, i, next);
             });
         }
-        thread_pool.wait();
+        thread_pool.wait(group);
         for (size_t i = 1; i < thread_pool.get_thread_count(); ++i)
             join(per_thread_result[0], std::move(per_thread_result[i]));
         return per_thread_result[0];

--- a/src/bvh/v2/mini_tree_builder.h
+++ b/src/bvh/v2/mini_tree_builder.h
@@ -195,11 +195,12 @@ private:
 
         // Iterate over bins to collect groups of primitives and build BVHs over them in parallel
         std::vector<Bvh<Node>> mini_trees(final_bins.bins.size());
+        ThreadPool::TaskGroup group;
         for (size_t i = 0; i < final_bins.bins.size(); ++i) {
             auto task = new BuildTask(this, mini_trees[i], std::move(final_bins[i].ids));
-            executor_.thread_pool.push([task] (size_t) { task->run(); delete task; });
+            executor_.thread_pool.push(group, [task] (size_t) { task->run(); delete task; });
         }
-        executor_.thread_pool.wait();
+        executor_.thread_pool.wait(group);
 
         return mini_trees;
     }

--- a/src/bvh/v2/stream.h
+++ b/src/bvh/v2/stream.h
@@ -16,6 +16,7 @@ public:
             data = std::move(default_val);
         return data;
     }
+    virtual ~InputStream() = default;
 
 protected:
     virtual size_t read_raw(void*, size_t) = 0;
@@ -27,6 +28,7 @@ public:
     template <typename T>
     bool write(const T& data) { return write_raw(&data, sizeof(T)); }
 
+    virtual ~OutputStream() = default;
 protected:
     virtual bool write_raw(const void*, size_t) = 0;
 };

--- a/src/bvh/v2/thread_pool.h
+++ b/src/bvh/v2/thread_pool.h
@@ -1,61 +1,111 @@
 #ifndef BVH_V2_THREAD_POOL_H
 #define BVH_V2_THREAD_POOL_H
 
-#include <thread>
-#include <mutex>
+#include <atomic>
 #include <condition_variable>
-#include <vector>
-#include <queue>
+#include <cstddef>
 #include <functional>
+#include <limits>
+#include <memory>
+#include <mutex>
+#include <queue>
+#include <thread>
+#include <utility>
+#include <vector>
 
 namespace bvh::v2 {
 
+
+
 class ThreadPool {
 public:
-    using Task = std::function<void(size_t)>;
+
+    /// Groups multiple tasks under a single unit of work. All tasks in the same group can be
+    /// be waited for completion using ``ThreadPool::wait()``.
+    class TaskGroup {
+    public:
+
+        TaskGroup()
+        : remaining_(0)
+        {}
+
+    private:
+        std::atomic<std::size_t> remaining_{0};
+       
+        TaskGroup(const TaskGroup&) = delete;
+        TaskGroup& operator=(const TaskGroup&) = delete;
+        TaskGroup(TaskGroup&&) = delete;
+        TaskGroup& operator=(TaskGroup&&) = delete;
+
+        friend ThreadPool;
+
+        inline void increment();
+        inline void decrement();
+        inline size_t remaining() const;
+    };
+
 
     /// Creates a thread pool with the given number of threads (a value of 0 tries to autodetect
     /// the number of threads and uses that as a thread count).
     ThreadPool(size_t thread_count = 0) { start(thread_count); }
 
     ~ThreadPool() {
-        wait();
+        wait_all();
         stop();
         join();
     }
 
-    inline void push(Task&& fun);
-    inline void wait();
+    template<typename F>
+    inline void push(TaskGroup &group, F&& fun);
+
+    /// Wait for completion of all tasks scoped under given `group`.
+    inline void wait(TaskGroup &group);
+
+    /// Wait for completion of all tasks.
+    inline void wait_all();
 
     size_t get_thread_count() const { return threads_.size(); }
 
 private:
+    /// Define a task function and its associated task group
+    struct Task {
+        TaskGroup *group = nullptr;
+        std::function<void(size_t)> fn;
+    };
+
     static inline void worker(ThreadPool*, size_t);
 
     inline void start(size_t);
     inline void stop();
     inline void join();
-
+    
     int busy_count_ = 0;
     bool should_stop_ = false;
     std::mutex mutex_;
     std::vector<std::thread> threads_;
     std::condition_variable avail_;
-    std::condition_variable done_;
+    std::condition_variable group_done_;
     std::queue<Task> tasks_;
 };
 
-void ThreadPool::push(Task&& task) {
+template<typename F>
+void ThreadPool::push(TaskGroup &group, F&& fun) {
     {
         std::unique_lock<std::mutex> lock(mutex_);
-        tasks_.emplace(std::move(task));
+        group.increment();
+        tasks_.emplace(Task{&group, std::forward<F>(fun)});
     }
     avail_.notify_one();
 }
 
-void ThreadPool::wait() {
+inline void ThreadPool::wait(TaskGroup &group) {
     std::unique_lock<std::mutex> lock(mutex_);
-    done_.wait(lock, [this] { return busy_count_ == 0 && tasks_.empty(); });
+    group_done_.wait(lock, [ &group] { return group.remaining() == 0; });
+}
+
+inline void ThreadPool::wait_all() {
+    std::unique_lock<std::mutex> lock(mutex_);
+    group_done_.wait(lock, [this] { return busy_count_ == 0 && tasks_.empty(); });  
 }
 
 void ThreadPool::worker(ThreadPool* pool, size_t thread_id) {
@@ -66,16 +116,24 @@ void ThreadPool::worker(ThreadPool* pool, size_t thread_id) {
             pool->avail_.wait(lock, [pool] { return pool->should_stop_ || !pool->tasks_.empty(); });
             if (pool->should_stop_ && pool->tasks_.empty())
                 break;
+
             task = std::move(pool->tasks_.front());
             pool->tasks_.pop();
             pool->busy_count_++;
         }
-        task(thread_id);
+
+        task.fn(thread_id);       
+        task.group->decrement();
+
         {
             std::unique_lock<std::mutex> lock(pool->mutex_);
             pool->busy_count_--;
         }
-        pool->done_.notify_one();
+
+        if(task.group->remaining() == 0)
+        {
+            pool->group_done_.notify_all();
+        }
     }
 }
 
@@ -97,6 +155,18 @@ void ThreadPool::stop() {
 void ThreadPool::join() {
     for (auto& thread : threads_)
         thread.join();
+}
+
+inline void ThreadPool::TaskGroup::increment() {
+  remaining_.fetch_add(1, std::memory_order_release);
+}
+
+inline void ThreadPool::TaskGroup::decrement() {
+  remaining_.fetch_sub(1, std::memory_order_release);
+}
+
+inline size_t ThreadPool::TaskGroup::remaining() const {
+  return remaining_.load(std::memory_order_acquire);
 }
 
 } // namespace bvh::v2

--- a/src/bvh/v2/top_down_sah_builder.h
+++ b/src/bvh/v2/top_down_sah_builder.h
@@ -64,6 +64,7 @@ protected:
         assert(config.min_leaf_size <= config.max_leaf_size);
     }
 
+    virtual ~TopDownSahBuilder() = default;
     virtual std::vector<size_t>& get_prim_ids() = 0;
     virtual std::optional<size_t> try_split(const BBox& bbox, size_t begin, size_t end) = 0;
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,6 +7,11 @@ target_link_libraries(simple_example PUBLIC bvh)
 set_target_properties(simple_example PROPERTIES CXX_STANDARD 20)
 add_test(NAME simple_example COMMAND simple_example)
 
+add_executable(threadpool_test threadpool_test.cpp)
+target_link_libraries(threadpool_test PUBLIC bvh)
+set_target_properties(threadpool_test PROPERTIES CXX_STANDARD 20)
+add_test(NAME threadpool_test COMMAND threadpool_test)
+
 add_executable(serialize serialize.cpp)
 target_link_libraries(serialize PUBLIC bvh)
 set_target_properties(serialize PROPERTIES CXX_STANDARD 20)

--- a/test/threadpool_test.cpp
+++ b/test/threadpool_test.cpp
@@ -13,19 +13,20 @@ int main() {
   bvh::v2::ThreadPool threadpool;
   std::vector<std::thread> threads;
 
-  size_t num_threads = 20;
-  size_t num_tasks = 1;
+  size_t num_threads = 200;
+  size_t num_tasks = 10;
   size_t num_millis = 45;
 
   auto estimated_time = std::chrono::milliseconds(
       num_tasks * num_millis * num_threads / threadpool.get_thread_count());
 
-  std::cout << "estimated time:"
+  std::cout << "total estimated time:"
             << std::chrono::duration_cast<std::chrono::seconds>(estimated_time)
             << std::endl;
 
-  // monitoring thread
-  threadpool.push([&](size_t) {
+  // monitoring thread, simply print time so that is is obvious so when that we
+  // can
+  threads.emplace_back([&]() {
     auto delta = std::max(std::chrono::milliseconds(1), estimated_time / 10);
     auto elasped = std::chrono::milliseconds(0);
     auto start = std::chrono::system_clock::now();
@@ -33,34 +34,35 @@ int main() {
     while (std::chrono::system_clock::now() < start + estimated_time) {
       std::this_thread::sleep_for(delta);
       elasped += delta;
-      std::cout << "[time: " << elasped << " / " << estimated_time << "]"
-                << std::endl;
+      std::cout << "[estimated remaining time: " << estimated_time - elasped
+                << "]" << std::endl;
     }
+
+    std::cout << "[test should be done by now]" << std::endl;
   });
 
+  // submit lots of task concurrently
   for (size_t i = 0; i < num_threads; ++i) {
-
     threads.emplace_back([&]() {
+      bvh::v2::ThreadPool::TaskGroup tgroup;
       for (int j = 0; j < num_tasks; ++j) {
-        threadpool.push([&](size_t) {
+        threadpool.push(tgroup, [&](size_t) {
           std::this_thread::sleep_for(std::chrono::milliseconds(num_millis));
         });
       }
 
-      threadpool.wait();
+      threadpool.wait(tgroup);
     });
   }
 
   std::cout << "wait for " << threads.size() << " threads" << std::endl;
-
   for (auto &th : threads) {
     if (th.joinable()) {
       th.join();
     }
   }
 
-  threadpool.wait();
-
+  threadpool.wait_all();
   std::cout << "done" << std::endl;
   return 0;
 }

--- a/test/threadpool_test.cpp
+++ b/test/threadpool_test.cpp
@@ -1,0 +1,66 @@
+#include <bvh/v2/bvh.h>
+#include <bvh/v2/executor.h>
+#include <bvh/v2/thread_pool.h>
+
+#include <chrono>
+#include <iostream>
+#include <thread>
+#include <vector>
+
+int main() {
+  std::cout << "threadpool_test" << std::endl;
+
+  bvh::v2::ThreadPool threadpool;
+  std::vector<std::thread> threads;
+
+  size_t num_threads = 20;
+  size_t num_tasks = 1;
+  size_t num_millis = 45;
+
+  auto estimated_time = std::chrono::milliseconds(
+      num_tasks * num_millis * num_threads / threadpool.get_thread_count());
+
+  std::cout << "estimated time:"
+            << std::chrono::duration_cast<std::chrono::seconds>(estimated_time)
+            << std::endl;
+
+  // monitoring thread
+  threadpool.push([&](size_t) {
+    auto delta = std::max(std::chrono::milliseconds(1), estimated_time / 10);
+    auto elasped = std::chrono::milliseconds(0);
+    auto start = std::chrono::system_clock::now();
+
+    while (std::chrono::system_clock::now() < start + estimated_time) {
+      std::this_thread::sleep_for(delta);
+      elasped += delta;
+      std::cout << "[time: " << elasped << " / " << estimated_time << "]"
+                << std::endl;
+    }
+  });
+
+  for (size_t i = 0; i < num_threads; ++i) {
+
+    threads.emplace_back([&]() {
+      for (int j = 0; j < num_tasks; ++j) {
+        threadpool.push([&](size_t) {
+          std::this_thread::sleep_for(std::chrono::milliseconds(num_millis));
+        });
+      }
+
+      threadpool.wait();
+    });
+  }
+
+  std::cout << "wait for " << threads.size() << " threads" << std::endl;
+
+  for (auto &th : threads) {
+    if (th.joinable()) {
+      th.join();
+    }
+  }
+
+  threadpool.wait();
+
+  std::cout << "done" << std::endl;
+  return 0;
+}


### PR DESCRIPTION
Hi,

I've been using bvh for a while, it's been great. easy to use and performant. Unfortunately, I have hit an issue recently. My application is highly concurrent and needs to build multiple bvh concurrently. I therefore created one `bvh::v2::ThreadPool` and use it for all bvh construction. In some cases, it hits a race condition and the bvh construction hangs.

I believe the problem is coming from `ThreadPool::worker` .  `pool->done_.notify_one();` wakes up one worker thread, and in some cases, when multiple tasks are finishing at the same time, a `pool->done_.notify_one();` could get missed.

Changing `pool->done_.notify_one();` to `pool->done_.notify_all();` does seem fix the issue. However that is not a great solution.
For example, 2 clients may ask to build a bvh at the same time. They will be both waiting for each others tasks be completed, due to how `ThreadPool::wait` is implemented. Ideally, a client would only be blocked until the completion of its tasks, regardless of what the other clients are scheduling to the threadpool.


With this in mind, I decided to modify the threadpool implementation so that multiple bvh can be built concurrently on the same threadpool.

For this I extended the threadpool with the concept of `TaskGroup`.

The idea is to scope all tasks into taskgroups, and a client now has to wait for the completion of a taskgroup.
```c++
ThreadPool threadpool;

ThreadPool::TaskGroup tgroup_1;
threadpool.push(tgroup_1, [&](size_t) { ... }); // task 1 in group 1
threadpool.push(tgroup_1, [&](size_t) { ... }); // task 2 in group 1

ThreadPool::TaskGroup tgroup_2;
threadpool.push(tgroup_2, [&](size_t) { ... }); // task 3 in group 2

threadpool.wait(tgroup_1); // wait for task 1 and task 2, from group 1
```

2 clients can push tasks into their own taskgroup and therefore not wait for each other anymore.

in `ThreadPool::worker` , worker threads are being notified only once a taskgroup goes to completion, hopefully keeping the overhead to a minimum.

I also added a `ThreadPool::wait_all`, which similarly to previous implementation, wait for completion of all tasks.

I have added a test (`threadpool_test.cpp`) that hangs with previous implementation, and works with new implementation.
note: `threadpool_test.cpp` will need to be modified a bit to make it compile with previous implementation:
* remove TaskGroup
* replace `threadpool.wait_all()` with `threadpool.wait()`

I am hoping that you would find this improvements useful.

Note : I experimented with another solution based of task stealing .  Instead of having `theadpool.wait` be blocking and doing nothing, it would actually be actively stealing tasks from the pool and evaluating them. That was promising but needed some modifications in the `ParallelExecutor::reduce` with how `thread_id` is handled. 

If you are interested I could do another PR with that solution.
